### PR TITLE
fix: Entity verification upon casting Blink

### DIFF
--- a/src/main/java/com/adamsmods/adamsarsplus/mixin/MixinEffectBlink.java
+++ b/src/main/java/com/adamsmods/adamsarsplus/mixin/MixinEffectBlink.java
@@ -19,9 +19,11 @@ import static com.adamsmods.adamsarsplus.ArsNouveauRegistry.SOUL_RIME_EFFECT;
 public class MixinEffectBlink {
     @Inject(at = @At(value = "HEAD"), cancellable = true, method = "onResolveEntity", remap = false)
     private void onResolveEntity0(EntityHitResult rayTraceResult, Level world, LivingEntity shooter, SpellStats spellStats, SpellContext spellContext, SpellResolver resolver, CallbackInfo ci){
-        LivingEntity living = (LivingEntity) rayTraceResult.getEntity();
-        if(living.hasEffect(SOUL_RIME_EFFECT.get())){
-            ci.cancel();
+        if (rayTraceResult.getEntity() instanceof LivingEntity) {
+            LivingEntity living = (LivingEntity) rayTraceResult.getEntity();
+            if (living.hasEffect(SOUL_RIME_EFFECT.get())) {
+                ci.cancel();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the issue described on https://github.com/AdamRogres/AdamsArsPlus/issues/4

Upon casting "Blink" to any `FallingBlockEntity`, the game would crash

Before:
https://github.com/user-attachments/assets/866d8e08-b0ed-4409-aabf-04f30e3e45f2

After:
https://github.com/user-attachments/assets/8f01f7e9-c30c-4610-a95f-5f306a4b1146

